### PR TITLE
Align TorchFold with production alphafast JAX

### DIFF
--- a/TorchFold_inference/torchfold/torchfold/alphafold3.py
+++ b/TorchFold_inference/torchfold/torchfold/alphafold3.py
@@ -481,6 +481,22 @@ class AlphaFold3(nn.Module):
         return output
 
     def forward(self, batch: dict[str, torch.Tensor], random_tape=None) -> dict[str, torch.Tensor]:
+        # first_run caches are only valid within one forward pass, but
+        # run_alphafold.py reuses one model across seeds and inputs. Values must
+        # be cleared too, not just flags -- pair_logits_list is appended to, and
+        # nn.Module attributes (Attention.pair_logits) must be left alone.
+        for _m in self.modules():
+            for _f in ('first_run', 'first_run_relative_encoding',
+                       'first_run_embed_bonds'):
+                if getattr(_m, _f, None) is False:
+                    setattr(_m, _f, True)
+            for _c in ('pair_logits_list', 'pair_logits', 'padded_pair_logits',
+                       'rel_feat', 'bonds_act', 'pair_act', 'queries_mask',
+                       'queries_single_cond', 'keys_mask', 'keys_single_cond',
+                       'single_cond', 'pair_cond'):
+                _v = getattr(_m, _c, None)
+                if isinstance(_v, (list, torch.Tensor)):
+                    setattr(_m, _c, [] if isinstance(_v, list) else None)
         batch = feat_batch.Batch.from_data_dict(batch)
         num_res = batch.num_res
 

--- a/TorchFold_inference/torchfold/torchfold/alphafold3.py
+++ b/TorchFold_inference/torchfold/torchfold/alphafold3.py
@@ -189,12 +189,16 @@ class Evoformer(nn.Module):
         self, msa_batch: features.MSA,
         pair_activations: torch.Tensor,
         pair_mask: torch.Tensor,
-        target_feat: torch.Tensor
+        target_feat: torch.Tensor,
+        msa_row_order: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Processes MSA and returns updated pair activations."""
         dtype = pair_activations.dtype
 
-        msa_batch = featurization.shuffle_msa(msa_batch)
+        if msa_row_order is None:
+            msa_batch = featurization.shuffle_msa(msa_batch)
+        else:
+            msa_batch = msa_batch.index_msa_rows(msa_row_order)
         msa_batch = featurization.truncate_msa_batch(msa_batch, self.num_msa)
 
         msa_mask = msa_batch.mask.to(dtype=dtype)
@@ -220,6 +224,7 @@ class Evoformer(nn.Module):
         prev: dict[str, torch.Tensor],  # variable
         target_feat: torch.Tensor,  # constant
         idx: int = 0,
+        msa_row_order: torch.Tensor | None = None,
     ) -> dict[str, torch.Tensor]:
 
         if self.first_run:
@@ -247,6 +252,7 @@ class Evoformer(nn.Module):
             pair_activations=pair_activations,
             pair_mask=self.pair_mask,
             target_feat=target_feat,
+            msa_row_order=msa_row_order,
         )
 
         single_activations = self.single_activations(target_feat)
@@ -315,11 +321,17 @@ class AlphaFold3(nn.Module):
         positions: torch.Tensor,
         noise_level_prev: torch.Tensor,
         mask: torch.Tensor,
-        noise_level: torch.Tensor
+        noise_level: torch.Tensor,
+        rotation_noise: torch.Tensor | None = None,
+        translation_noise: torch.Tensor | None = None,
+        standard_noise: torch.Tensor | None = None,
+        return_denoised: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
 
         positions = diffusion_head.random_augmentation(
-            positions=positions, mask=mask
+            positions=positions, mask=mask,
+            rotation_noise=rotation_noise,
+            translation_noise=translation_noise,
         )
 
         gamma = self.gamma_0 * (noise_level > self.gamma_min)
@@ -327,8 +339,10 @@ class AlphaFold3(nn.Module):
 
         noise_scale = self.noise_scale * \
             torch.sqrt(t_hat**2 - noise_level_prev**2)
-        noise = noise_scale * \
-            torch.randn(size=positions.shape, device=noise_scale.device)
+        if standard_noise is None:
+            standard_noise = torch.randn(
+                size=positions.shape, device=noise_scale.device)
+        noise = noise_scale * standard_noise
         # noise = noise_scale
         positions_noisy = positions + noise
 
@@ -342,12 +356,15 @@ class AlphaFold3(nn.Module):
         d_t = noise_level - t_hat
         positions_out = positions_noisy + self.step_scale * d_t * grad
 
+        if return_denoised:
+            return positions_out, positions_denoised
         return positions_out
 
     def _sample_diffusion(
         self,
         batch: feat_batch.Batch,
         embeddings: dict[str, torch.Tensor],
+        random_tape: dict[str, torch.Tensor] | None = None,
     ) -> dict[str, torch.Tensor]:
         """Sample using denoiser on batch."""
 
@@ -359,9 +376,16 @@ class AlphaFold3(nn.Module):
         noise_levels = diffusion_head.noise_schedule(
             torch.linspace(0, 1, self.diffusion_steps + 1, device=device))
 
-        positions = torch.randn(
-            (num_samples,) + mask.shape + (3,), device=device)
+        if random_tape is None:
+            positions = torch.randn(
+                (num_samples,) + mask.shape + (3,), device=device)
+        else:
+            positions = random_tape['initial_positions_noise']
         positions *= noise_levels[0]
+        trajectory = None if random_tape is None else torch.empty(
+            (self.diffusion_steps,) + positions.shape, device=device)
+        first_denoised = None if random_tape is None else torch.empty_like(
+            positions)
 
         if USE_DIST:
             assert self.diffusion_steps == 200
@@ -428,21 +452,35 @@ class AlphaFold3(nn.Module):
         else:
             for sample_idx in range(num_samples):
                 for step_idx in trange(self.diffusion_steps, desc=f"Diffusion {sample_idx}"):
-                    positions[sample_idx] = self._apply_denoising_step(
+                    step_output = self._apply_denoising_step(
                         batch,
                         embeddings,
                         positions[sample_idx],
                         noise_levels[step_idx],
                         mask,
                         noise_levels[1 + step_idx],
+                        rotation_noise=None if random_tape is None else random_tape['rotation_noise'][step_idx, sample_idx],
+                        translation_noise=None if random_tape is None else random_tape['translation_noise'][step_idx, sample_idx],
+                        standard_noise=None if random_tape is None else random_tape['diffusion_noise'][step_idx, sample_idx],
+                        return_denoised=random_tape is not None and step_idx == 0,
                     )
+                    if random_tape is not None and step_idx == 0:
+                        positions[sample_idx], first_denoised[sample_idx] = step_output
+                    else:
+                        positions[sample_idx] = step_output
+                    if trajectory is not None:
+                        trajectory[step_idx, sample_idx] = positions[sample_idx]
 
 
         final_dense_atom_mask = torch.tile(mask[None], (num_samples, 1, 1))
 
-        return {'atom_positions': positions, 'mask': final_dense_atom_mask}
+        output = {'atom_positions': positions, 'mask': final_dense_atom_mask}
+        if trajectory is not None:
+            output['trajectory'] = trajectory
+            output['denoised_step_1'] = first_denoised
+        return output
 
-    def forward(self, batch: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    def forward(self, batch: dict[str, torch.Tensor], random_tape=None) -> dict[str, torch.Tensor]:
         batch = feat_batch.Batch.from_data_dict(batch)
         num_res = batch.num_res
 
@@ -461,18 +499,25 @@ class AlphaFold3(nn.Module):
 
         t1 = time.time()
         rk = dist.get_rank() if USE_DIST else 0
+        num_trunk_passes = self.num_recycles + 1
+        checkpoint_indices = tuple(range(num_trunk_passes))
+        trunk_checkpoints = {}
         # logger.info(f"rank {rk}: Start running Evoformer")
-        for i in range(self.num_recycles + 1):
+        for i in range(num_trunk_passes):
             embeddings = self.evoformer(
                 batch=batch,
                 prev=embeddings,
                 target_feat=target_feat,
                 idx=i,
+                msa_row_order=None if random_tape is None else random_tape['msa_row_order'][i],
             )
+            if random_tape is not None and i in checkpoint_indices:
+                trunk_checkpoints[i] = (
+                    embeddings['single'].clone(), embeddings['pair'].clone())
 
         t2 = time.time()
         # logger.info(f"Time taken for Evoformer: {t2 - t1:.4f}s")
-        samples = self._sample_diffusion(batch, embeddings)
+        samples = self._sample_diffusion(batch, embeddings, random_tape)
         t3 = time.time()
         # logger.info(f"Time taken for Diffusion: {t3 - t2:.4f}s")
 
@@ -501,8 +546,22 @@ class AlphaFold3(nn.Module):
         distogram = self.distogram_head(batch, embeddings)
         # logger.info(f"Time taken for Distogram: {time.time() - t4:.4f}s")
 
-        return {
+        output = {
             'diffusion_samples': samples,
             'distogram': distogram,
             **confidence_output,
         }
+        if random_tape is not None:
+            output['num_trunk_passes'] = num_trunk_passes
+            output['trunk_checkpoint_passes'] = tuple(
+                index + 1 for index in checkpoint_indices)
+            output['single_embeddings'] = embeddings['single']
+            output['pair_embeddings'] = embeddings['pair']
+        if random_tape is not None and checkpoint_indices:
+            output['trunk_single_checkpoints'] = torch.stack(
+                [trunk_checkpoints[index][0] for index in checkpoint_indices])
+            output['trunk_pair_checkpoints'] = torch.stack(
+                [trunk_checkpoints[index][1] for index in checkpoint_indices])
+        if random_tape is None:
+            distogram.pop('distogram')
+        return output

--- a/TorchFold_inference/torchfold/torchfold/alphafold3.py
+++ b/TorchFold_inference/torchfold/torchfold/alphafold3.py
@@ -462,7 +462,7 @@ class AlphaFold3(nn.Module):
         t1 = time.time()
         rk = dist.get_rank() if USE_DIST else 0
         # logger.info(f"rank {rk}: Start running Evoformer")
-        for i in range(self.num_recycles):
+        for i in range(self.num_recycles + 1):
             embeddings = self.evoformer(
                 batch=batch,
                 prev=embeddings,

--- a/TorchFold_inference/torchfold/torchfold/fastnn/config.py
+++ b/TorchFold_inference/torchfold/torchfold/fastnn/config.py
@@ -1,3 +1,8 @@
+# Opt-in accuracy controls used by the AlphaFast parity validator.
+strict_random_augmentation = False
+strict_diffusion_explicit_highest = False
+
+
 # options: ["torch", "triton"]
 layer_norm_implementation = "torch"
 

--- a/TorchFold_inference/torchfold/torchfold/nn/atom_cross_attention.py
+++ b/TorchFold_inference/torchfold/torchfold/nn/atom_cross_attention.py
@@ -10,6 +10,23 @@ from torchfold.nn import atom_layout, utils
 from torchfold.nn.diffusion_transformer import DiffusionCrossAttTransformer
 
 from torchfold import fastnn
+from torchfold.fastnn import config as fastnn_config
+
+
+def _explicit_highest_projection(
+    module: nn.Module, value: torch.Tensor
+) -> torch.Tensor:
+    if not fastnn_config.strict_diffusion_explicit_highest:
+        return module(value)
+    previous_precision = torch.get_float32_matmul_precision()
+    previous_allow_tf32 = torch.backends.cuda.matmul.allow_tf32
+    try:
+        torch.set_float32_matmul_precision("highest")
+        torch.backends.cuda.matmul.allow_tf32 = False
+        return module(value)
+    finally:
+        torch.set_float32_matmul_precision(previous_precision)
+        torch.backends.cuda.matmul.allow_tf32 = previous_allow_tf32
 
 
 @dataclasses.dataclass(frozen=True)
@@ -129,7 +146,9 @@ class AtomCrossAttEncoder(nn.Module):
 
         # Compute per-atom single conditioning
         # Shape (num_tokens, num_dense, channels)
-        act = self.embed_ref_pos(batch.ref_structure.positions)
+        act = _explicit_highest_projection(
+            self.embed_ref_pos, batch.ref_structure.positions
+        )
         act += self.embed_ref_mask(batch.ref_structure.mask[:, :, None].to(
             dtype=self.embed_ref_mask.weight.dtype))
 
@@ -205,8 +224,10 @@ class AtomCrossAttEncoder(nn.Module):
 
             # If provided, broadcast single conditioning from trunk to all queries
             if trunk_single_cond is not None:
-                trunk_single_cond = self.embed_trunk_single_cond(
-                    self.lnorm_trunk_single_cond(trunk_single_cond))
+                trunk_single_cond = _explicit_highest_projection(
+                    self.embed_trunk_single_cond,
+                    self.lnorm_trunk_single_cond(trunk_single_cond),
+                )
                 queries_single_cond += atom_layout.convert(
                     batch.atom_cross_att.tokens_to_queries,
                     trunk_single_cond,
@@ -238,8 +259,10 @@ class AtomCrossAttEncoder(nn.Module):
             pair_act = row_act[:, :, None, :] + col_act[:, None, :, :]
 
             if trunk_pair_cond is not None:
-                trunk_pair_cond = self.embed_trunk_pair_cond(
-                    self.lnorm_trunk_pair_cond(trunk_pair_cond))
+                trunk_pair_cond = _explicit_highest_projection(
+                    self.embed_trunk_pair_cond,
+                    self.lnorm_trunk_pair_cond(trunk_pair_cond),
+                )
 
                 # Create the GatherInfo into a flattened trunk_pair_cond from the
                 # queries and keys gather infos.
@@ -292,8 +315,9 @@ class AtomCrossAttEncoder(nn.Module):
             )
             offsets = queries_ref_pos[:, :, None, :] - keys_ref_pos[:, None, :, :]
 
-            pair_act += (self.embed_pair_offsets_1(offsets)
-                        * offsets_valid[:, :, :, None])
+            pair_act += (
+                _explicit_highest_projection(self.embed_pair_offsets_1, offsets)
+                * offsets_valid[:, :, :, None])
 
             # Embed pairwise inverse squared distances
             sq_dists = torch.sum(torch.square(offsets), dim=-1)
@@ -326,7 +350,9 @@ class AtomCrossAttEncoder(nn.Module):
                 layout_axes=(-3, -2),
             )
 
-            queries_act = self.atom_positions_to_features(queries_act)
+            queries_act = _explicit_highest_projection(
+                self.atom_positions_to_features, queries_act
+            )
             queries_act *= self.queries_mask[..., None]
             queries_act += self.queries_single_cond
 
@@ -416,8 +442,9 @@ class AtomCrossAttDecoder(nn.Module):
 
         queries_act *= enc.queries_mask[..., None]
         queries_act = self.atom_features_layer_norm(queries_act)
-        queries_position_update = self.atom_features_to_position_update(
-            queries_act)
+        queries_position_update = _explicit_highest_projection(
+            self.atom_features_to_position_update, queries_act
+        )
         position_update = atom_layout.convert(
             batch.atom_cross_att.queries_to_token_atoms,
             queries_position_update,

--- a/TorchFold_inference/torchfold/torchfold/nn/diffusion_head.py
+++ b/TorchFold_inference/torchfold/torchfold/nn/diffusion_head.py
@@ -34,15 +34,20 @@ def noise_schedule(t, smin=0.0004, smax=160.0, p=7):
     )
 
 
-def random_rotation(device, dtype):
+def rotation_from_noise(noise):
     # Create a random rotation (Gram-Schmidt orthogonalization of two
     # random normal vectors)
-    v0, v1 = torch.randn(size=(2, 3), dtype=dtype, device=device)
+    v0, v1 = noise
     e0 = v0 / torch.clamp(torch.linalg.norm(v0), min=1e-10)
     v1 = v1 - e0 * torch.dot(v1, e0)
     e1 = v1 / torch.clamp(torch.linalg.norm(v1), min=1e-10)
     e2 = torch.cross(e0, e1, dim=-1)
     return torch.stack([e0, e1, e2])
+
+
+def random_rotation(device, dtype):
+    noise = torch.randn(size=(2, 3), dtype=dtype, device=device)
+    return rotation_from_noise(noise)
 
 
 def _strict_random_augmentation(function):
@@ -67,6 +72,8 @@ def _strict_random_augmentation(function):
 def random_augmentation(
     positions: torch.Tensor,
     mask: torch.Tensor,
+    rotation_noise: torch.Tensor | None = None,
+    translation_noise: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Apply random rigid augmentation.
 
@@ -81,9 +88,13 @@ def random_augmentation(
     center = utils.mask_mean(
         mask[..., None], positions, dim=(-2, -3), keepdim=True, eps=1e-6
     )
-    rot = random_rotation(device=positions.device, dtype=positions.dtype)
-    translation = torch.randn(
-        size=(3,), dtype=positions.dtype, device=positions.device)
+    if rotation_noise is None:
+        rot = random_rotation(device=positions.device, dtype=positions.dtype)
+        translation = torch.randn(
+            size=(3,), dtype=positions.dtype, device=positions.device)
+    else:
+        rot = rotation_from_noise(rotation_noise)
+        translation = translation_noise
 
     augmented_positions = (
         torch.einsum(

--- a/TorchFold_inference/torchfold/torchfold/nn/diffusion_head.py
+++ b/TorchFold_inference/torchfold/torchfold/nn/diffusion_head.py
@@ -1,3 +1,4 @@
+import functools
 import torch
 import torch.nn as nn
 
@@ -7,6 +8,7 @@ from torchfold.nn.diffusion_transformer import DiffusionTransformer, DiffusionTr
 from torchfold.nn.atom_cross_attention import AtomCrossAttEncoder, AtomCrossAttDecoder
 
 from torchfold import fastnn
+from torchfold.fastnn import config as fastnn_config
 
 # Carefully measured by averaging multimer training set.
 SIGMA_DATA = 16.0
@@ -43,6 +45,25 @@ def random_rotation(device, dtype):
     return torch.stack([e0, e1, e2])
 
 
+def _strict_random_augmentation(function):
+    @functools.wraps(function)
+    def wrapped(*args, **kwargs):
+        if not fastnn_config.strict_random_augmentation:
+            return function(*args, **kwargs)
+        previous_precision = torch.get_float32_matmul_precision()
+        previous_allow_tf32 = torch.backends.cuda.matmul.allow_tf32
+        try:
+            torch.set_float32_matmul_precision("highest")
+            torch.backends.cuda.matmul.allow_tf32 = False
+            return function(*args, **kwargs)
+        finally:
+            torch.set_float32_matmul_precision(previous_precision)
+            torch.backends.cuda.matmul.allow_tf32 = previous_allow_tf32
+
+    return wrapped
+
+
+@_strict_random_augmentation
 def random_augmentation(
     positions: torch.Tensor,
     mask: torch.Tensor,
@@ -133,6 +154,22 @@ class DiffusionHead(nn.Module):
         self.single_cond = None
         self.pair_cond = None
 
+    @staticmethod
+    def _explicit_highest_projection(
+        module: nn.Module, value: torch.Tensor
+    ) -> torch.Tensor:
+        if not fastnn_config.strict_diffusion_explicit_highest:
+            return module(value)
+        previous_precision = torch.get_float32_matmul_precision()
+        previous_allow_tf32 = torch.backends.cuda.matmul.allow_tf32
+        try:
+            torch.set_float32_matmul_precision("highest")
+            torch.backends.cuda.matmul.allow_tf32 = False
+            return module(value)
+        finally:
+            torch.set_float32_matmul_precision(previous_precision)
+            torch.backends.cuda.matmul.allow_tf32 = previous_allow_tf32
+
     def _conditioning(
         self,
         batch,
@@ -150,8 +187,9 @@ class DiffusionHead(nn.Module):
             ).to(dtype=pair_embedding.dtype)
             features_2d = torch.concatenate([pair_embedding, rel_features], dim=-1)
 
-            pair_cond = self.pair_cond_initial_projection(
-                self.pair_cond_initial_norm(features_2d)
+            pair_cond = self._explicit_highest_projection(
+                self.pair_cond_initial_projection,
+                self.pair_cond_initial_norm(features_2d),
             )
 
             pair_cond += self.pair_transition_0(pair_cond)
@@ -160,8 +198,10 @@ class DiffusionHead(nn.Module):
             target_feat = embeddings['target_feat']
             features_1d = torch.concatenate(
                 [single_embedding, target_feat], dim=-1)
-            single_cond = self.single_cond_initial_projection(
-                self.single_cond_initial_norm(features_1d))
+            single_cond = self._explicit_highest_projection(
+                self.single_cond_initial_projection,
+                self.single_cond_initial_norm(features_1d),
+            )
 
             self.single_cond = single_cond
             self.pair_cond = pair_cond
@@ -172,8 +212,9 @@ class DiffusionHead(nn.Module):
             (1 / 4) * torch.log(noise_level / SIGMA_DATA)
         )
 
-        single_cond += self.noise_embedding_initial_projection(
-            self.noise_embedding_initial_norm(noise_embedding)
+        single_cond += self._explicit_highest_projection(
+            self.noise_embedding_initial_projection,
+            self.noise_embedding_initial_norm(noise_embedding),
         )
 
         single_cond += self.single_transition_0(single_cond)
@@ -213,8 +254,9 @@ class DiffusionHead(nn.Module):
         )
         act = enc.token_act
 
-        act += self.single_cond_embedding_projection(
-            self.single_cond_embedding_norm(trunk_single_cond)
+        act += self._explicit_highest_projection(
+            self.single_cond_embedding_projection,
+            self.single_cond_embedding_norm(trunk_single_cond),
         )
 
         act = self.transformer(

--- a/TorchFold_inference/torchfold/torchfold/nn/diffusion_transformer.py
+++ b/TorchFold_inference/torchfold/torchfold/nn/diffusion_transformer.py
@@ -210,7 +210,7 @@ class DiffusionTransformer(nn.Module):
 
         self.num_super_blocks = self.num_blocks // self.super_block_size
 
-        self.pair_input_layer_norm = fastnn.LayerNorm(self.c_pair_cond)
+        self.pair_input_layer_norm = fastnn.LayerNorm(self.c_pair_cond, bias=False)
         self.pair_logits_projection = nn.ModuleList(
             [nn.Linear(self.c_pair_cond, self.super_block_size * self.num_head, bias=False) for _ in range(self.num_super_blocks)])
 

--- a/TorchFold_inference/torchfold/torchfold/nn/head.py
+++ b/TorchFold_inference/torchfold/torchfold/nn/head.py
@@ -72,6 +72,7 @@ class DistogramHead(nn.Module):
         return {
             'bin_edges': self.breaks,
             'contact_probs': contact_probs,
+            'distogram': logits,
         }
 
 


### PR DESCRIPTION
1. b281208 — Align TorchFold with the production JAX contract. Run **num_recycles + 1** trunk passes to match JAX's "recycles are additional passes" semantics, and **disable bias** on DiffusionTransformer.pair_input_layer_norm to match JAX's create_offset=False.
2. a88050c — Add opt-in A-class precision fixes. Add **strict_random_augmentation** and **strict_diffusion_explicit_highest** switches that force strict FP32 exactly where the JAX source annotates precision='highest'; both default to off.
3. 46103d2 — Add opt-in **deterministic parity capture**. Add default-off per-pass tensor capture for JAX parity comparison, computation-neutral when disabled.
4. 20d935a — **Clear first-run cache**. Reset the 8 first_run caches and their cached values at the top of AlphaFold3.forward, fixing same-process crashes across structures and silent corruption across seeds.